### PR TITLE
Add package manifest spec

### DIFF
--- a/specs/package-manifest.md
+++ b/specs/package-manifest.md
@@ -1,48 +1,42 @@
-# 1 Package Manifest API
+# 1 Subgraph Manifest
 ##### v.0.0.1
 
 ## 1.1 Overview
-The package manifest specifies all the information required to index and query a specific package. It is the entry point to your package, so to speak.
+The Subgraph manifest specifies all the information required to index and query a specific subgraph. It is the entry point to your subgraph, so to speak.
 
-The package manifest, and all the files linked from it, are what is deployed to IPFS, and hashed to produce a package ID that can be referenced and used to retrieve your package in The Graph.
+The subgraph manifest, and all the files linked from it, are what is deployed to IPFS, and hashed to produce a subgraph ID that can be referenced and used to retrieve your subgraph in The Graph.
 
 ## 1.2 Format
-Any data format which has a well-defined 1:1 mapping with [IPLD Canonical Format](https://github.com/ipld/specs/blob/master/IPLD.md#serialized-data-formats) may be used to define a package manifest. This includes YAML and JSON. Examples in this document will be provided in YAML.
+Any data format which has a well-defined 1:1 mapping with [IPLD Canonical Format](https://github.com/ipld/specs/blob/master/IPLD.md#serialized-data-formats) may be used to define a subgraph manifest. This includes YAML and JSON. Examples in this document will be provided in YAML.
 
 ## 1.3 Top-Level API
 
 | Field  | Type | Description   |
 | --- | --- | --- |
 | **specVersion** | *String*   | A semver version indicating which version of this API is being used.|
-| **schema**   | [*Schema*](## 1.4 Schema)   | The GraphQL schema of this package|
-| **ingestData**| [*[Ingest Data Spec]*](## 1.5 Ingest Data)| Each Ingest Data specs defines data which will be ingested, and transformation logic to derive the state of the package's entities based on the source data.|
+| **schema**   | [*Schema*](## 1.4 Schema) | The GraphQL schema of this subgraph|
+| **dataSources**| [*[Data Source Spec]*](## 1.5 Data Source)| Each Data Source spec defines data which will be ingested, and transformation logic to derive the state of the subgraph's entities based on the source data.|
 
 ## 1.4 Schema
 
 | Field | Type | Description |
 | --- | --- | --- |
-| **path**| [*Path*](## 1.6 Path) | The path of the GraphQL IDL file, either locally or on IPFS |
+| **file**| [*Path*](## 1.6 Path) | The path of the GraphQL IDL file, either locally or on IPFS |
 
-## 1.5 Ingest Data
+## 1.5 Data Source
 
 | Field | Type | Description |
 | --- | --- | --- |
-| **data** | [*Data*](### 1.5.1 Data) | The source data on a blockchain such as Ethereum |
+| **kind** | *String | The type of data source. Possible values: *ethereum/contract*|
+| **name** | *String* | The name of the source data. Will be used to generate APIs in mapping, and also for self-documentation purposes |
+| **source** | [*EthereumContractSource*](### 1.5.1 EthereumContractSource) | The source data on a blockchain such as Ethereum |
 | **mapping** | [*Mapping*](### 1.5.2 Mapping) | The transformation logic applied to the data prior to being indexed |
 
-### 1.5.1 Data
+### 1.5.1 EthereumContractSource
 
 | Field | Type | Description |
 | --- | --- | --- |
-| **kind** | *String* | The type of data that is being indexed. Supported values: *ethereum/contract*.|
-| **name** | *String* | The name of the source data. Will be used to generate APIs in mapping, and also for self-documentation purposes |
 | **address** | *String* | The address of the source data in its respective blockchain |
-| **structure** | [*EthereumContractStructure*](#### 1.5.1.1 EthereumContractStructure) | The structure of the source data |
-
-#### 1.5.1.1 EthereumContractStructure
-
-| Field | Type | Description |
-| --- | --- | --- |
 | **abi** | *String* | The name of the ABI for this Ethereum contract (see `abis` in `mapping` manifest) |
 
 ### 1.5.2 Mapping
@@ -59,7 +53,14 @@ The `mapping` field may be one of the following supported mapping manifests:
 | **entities** | *[String]* | A list of entities which will be ingested as part of this mapping. Must correspond to names of entities in the GraphQL IDL |
 | **abis** | *ABI* | ABIs for the contract classes which should be generated in the Mapping ABI. Name is also used to reference the ABI elsewhere in the manifest |
 | **eventHandlers** | *EventHandler* | Handlers for specific events, which will be defined in the mapping script |
-| **source** | [*Path*](## 1.6 Path) | The path of the mapping script |
+| **file** | [*Path*](## 1.6 Path) | The path of the mapping script |
+
+#### 1.5.2.2 EventHandler
+
+| Field | Type | Description |
+| --- | --- | --- |
+| **event** | *String* | An identifier for an event which will be handled in the mapping script. For Ethereum contracts, this must be the full event signature to disambiguate from events which may share the same name. |
+| **handler** | *String* | The name of an exported function in the mapping script which should handle the specified event. |
 
 ## 1.6 Path
 A path has one field `path` which either refers to a path of a file on the local dev machine, or an [IPLD link](https://github.com/ipld/specs/blob/master/IPLD.md#linking-between-nodes).


### PR DESCRIPTION
Adds a spec for the package manifest which users will use to define a package.

There's several things I'd like to change about this API based on the experience we now have building on it, but with this version I went with what's in the working product as a starting point (using the latest memefactory example as reference).

The parts that are included in this PR currently are ready for review.